### PR TITLE
Add Vite setup for running React app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Bioscoop Planner
+
+Deze repository bevat de broncode voor een simpele React-applicatie waarmee je filmprogramma's kunt plannen. De applicatie gebruikt Firebase voor opslag en authenticatie. 
+
+## Installatie
+
+1. Zorg dat [Node.js](https://nodejs.org/) is geïnstalleerd.
+2. Installeer de dependencies:
+
+```bash
+npm install
+```
+
+3. Start de ontwikkelserver:
+
+```bash
+npm run dev
+```
+
+De applicatie is daarna bereikbaar op `http://localhost:3000`.
+
+## Builden voor productie
+
+```bash
+npm run build
+```
+
+De geoptimaliseerde bestanden worden geplaatst in de map `dist/`, waarmee je de app bijvoorbeeld op GitHub Pages kunt hosten.
+
+## Configuratie
+
+De applicatie verwacht enkele globale variabelen voor Firebase-configuratie en authenticatie. Als je deze via een bundler of direct in `index.html` definieert, worden ze gebruikt bij het starten van de app:
+
+```html
+<script>
+  window.__firebase_config = JSON.stringify({
+    apiKey: "...",
+    authDomain: "...",
+    projectId: "...",
+    storageBucket: "...",
+    messagingSenderId: "...",
+    appId: "..."
+  });
+  window.__app_id = 'mijn-app-id';
+  window.__initial_auth_token = null; // optioneel
+</script>
+```
+
+Zonder deze configuratie kun je Firebase niet gebruiken en zal de app foutmeldingen tonen.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bioscoop Planner</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "bioscoop-planner",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "firebase": "^10.12.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.0.8"
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- add package.json with React, Firebase and Vite
- configure Vite and create entrypoint files
- document how to install and run the project

## Testing
- `npm list --depth=0`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842ab00fa7883289de1a0070285e4e3