### PR TITLE
Fix GitHub Pages assets path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ De applicatie is daarna bereikbaar op `http://localhost:3000`.
 ```bash
 npm run build
 ```
+Wanneer je de applicatie op GitHub Pages plaatst, zorg dan dat in `vite.config.js` de optie `base: './'` is ingesteld. Hiermee worden de gebuildde assets vanaf het juiste pad geladen en voorkom je een wit scherm.
 
 De geoptimaliseerde bestanden worden geplaatst in de map `dist/`, waarmee je de app bijvoorbeeld op GitHub Pages kunt hosten.
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,4 +6,6 @@ export default defineConfig({
   server: {
     port: 3000,
   },
+  // Gebruik een relatieve basis zodat assets correct laden op GitHub Pages
+  base: './',
 });


### PR DESCRIPTION
## Summary
- ensure Vite uses a relative `base` so assets load correctly when hosted in a subfolder
- document the `base` option in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842f18bb6448328bbd0f8939725d252