### PR TITLE
Add movie features and compact scheduler header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,7 +18,11 @@ const LOCAL_STORAGE_KEY = `movies_${appId}`;
 const loadLocalMovies = () => {
     try {
         const data = localStorage.getItem(LOCAL_STORAGE_KEY);
-        return data ? JSON.parse(data) : [];
+        const parsed = data ? JSON.parse(data) : [];
+        return parsed.map(m => ({
+            ...m,
+            features: m.features || { NL: false, OV: false, "2D": false, "3D": false }
+        }));
     } catch {
         return [];
     }
@@ -130,7 +134,8 @@ function App() {
             const moviesData = snapshot.docs.map(doc => ({
                 id: doc.id,
                 ...doc.data(),
-                duration: doc.data().duration ? parseInt(doc.data().duration, 10) : 90
+                duration: doc.data().duration ? parseInt(doc.data().duration, 10) : 90,
+                features: doc.data().features || { NL: false, OV: false, "2D": false, "3D": false }
             }));
             setMovies(moviesData);
         }, (error) => {
@@ -403,6 +408,7 @@ function App() {
                 date: dayFullDate,
                 time: slotTime,
                 hall: hallName,
+                features: { NL: false, OV: false, "2D": false, "3D": false },
             };
             await handleSaveMovie(newPredefinedMovie);
         }
@@ -434,6 +440,7 @@ function App() {
                 date: dayFullDate,
                 time: slotTime,
                 hall: hallName,
+                features: { NL: false, OV: false, "2D": false, "3D": false },
             };
             await handleSaveMovie(newMovie); // Add directly
         } else {
@@ -557,6 +564,12 @@ function App() {
                     overflow: hidden;
                     text-overflow: ellipsis;
                     flex-grow: 1;
+                }
+                .movie-card .features span {
+                    background-color: rgba(55, 48, 163, 0.9);
+                    padding: 0 2px;
+                    border-radius: 2px;
+                    font-size: 0.55rem;
                 }
                 .movie-card button {
                     flex-shrink: 0;
@@ -709,14 +722,14 @@ function App() {
                             <h2 className="text-2xl font-semibold mb-5 text-center">Weekprogramma</h2>
 
                             {/* Week Navigation */}
-                            <div className="flex justify-between items-center mb-4 px-2">
+                            <div className="flex flex-wrap justify-between items-center mb-4 px-2 gap-2">
                                 <button
                                     onClick={goToPreviousWeek}
                                     className="bg-indigo-500 hover:bg-indigo-600 text-white py-2 px-4 rounded-lg transition-all duration-200 shadow-md"
                                 >
                                     &larr; Vorige week
                                 </button>
-                                <span className="text-xl font-semibold text-center">
+                                <span className="text-xl font-semibold text-center flex-grow">
                                     {new Intl.DateTimeFormat('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' }).format(currentWeekStart)}
                                     {' - '}
                                     {new Intl.DateTimeFormat('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' }).format(daysOfWeek[6].fullDate ? parseDate(daysOfWeek[6].fullDate) : new Date())}
@@ -727,8 +740,6 @@ function App() {
                                 >
                                     Volgende week &rarr;
                                 </button>
-                            </div>
-                            <div className="text-center mb-4">
                                 <button
                                     onClick={goToToday}
                                     className="bg-purple-500 hover:bg-purple-600 text-white py-2 px-5 rounded-lg transition-all duration-200 shadow-md"
@@ -786,6 +797,11 @@ function App() {
                                                                         <div className="movie-info">
                                                                             <p className="movie-time">{movie.time}</p>
                                                                             <h4 className="movie-title">{movie.title}</h4>
+                                                                            <div className="features flex gap-1 ml-1">
+                                                                                {movie.features && Object.keys(movie.features).filter(f => movie.features[f]).map(f => (
+                                                                                    <span key={f} className="bg-purple-900 px-1 rounded text-[0.55rem]">{f}</span>
+                                                                                ))}
+                                                                            </div>
                                                                         </div>
                                                                         <button
                                                                             onClick={(e) => { e.stopPropagation(); handleDeleteMovie(movie.id); }}
@@ -850,6 +866,11 @@ function App() {
                                                                         <div className="movie-info">
                                                                             <p className="movie-time">{movie.time}</p>
                                                                             <h4 className="movie-title">{movie.title}</h4>
+                                                                            <div className="features flex gap-1 ml-1">
+                                                                                {movie.features && Object.keys(movie.features).filter(f => movie.features[f]).map(f => (
+                                                                                    <span key={f} className="bg-purple-900 px-1 rounded text-[0.55rem]">{f}</span>
+                                                                                ))}
+                                                                            </div>
                                                                         </div>
                                                                         <button
                                                                             onClick={(e) => { e.stopPropagation(); handleDeleteMovie(movie.id); }}

--- a/src/components/MovieManagementPage.jsx
+++ b/src/components/MovieManagementPage.jsx
@@ -9,11 +9,13 @@ function MovieManagementPage({ movies, handleEditMovie, handleDeleteMovie }) {
                     movies.map((movie) => (
                         <div key={movie.id} className="bg-purple-800 p-4 rounded-lg shadow-md flex flex-col justify-between">
                             <div>
-                                <h3 className="text-lg font-bold">{movie.title}</h3>
-                                <p className="text-purple-300 text-sm">Datum: {movie.date}</p>
-                                <p className="text-purple-300 text-sm">Tijd: {movie.time}</p>
-                                <p className="text-purple-300 text-sm">Zaal: {movie.hall}</p>
-                                <p className="text-purple-300 text-sm">Duur: {movie.duration} min</p>
+                                <h3 className="text-lg font-bold mb-2">{movie.title}</h3>
+                                <p className="text-purple-300 text-sm mb-2">Duur: {movie.duration} min</p>
+                                <div className="flex gap-2 mb-2">
+                                    {movie.features && Object.keys(movie.features).filter(f => movie.features[f]).map(f => (
+                                        <span key={f} className="bg-purple-600 px-2 py-0.5 rounded text-xs">{f}</span>
+                                    ))}
+                                </div>
                             </div>
                             <div className="mt-4 flex gap-2">
                                 <button

--- a/src/components/MovieModal.jsx
+++ b/src/components/MovieModal.jsx
@@ -19,6 +19,7 @@ function MovieModal({
     const [selectedHall, setSelectedHall] = useState(halls[0]);
     const [selectedPredefinedMovie, setSelectedPredefinedMovie] = useState('');
     const [internalMessage, setInternalMessage] = useState('');
+    const [features, setFeatures] = useState({ NL: false, OV: false, "2D": false, "3D": false });
 
     useEffect(() => {
         if (show) {
@@ -31,6 +32,7 @@ function MovieModal({
             setSelectedHall(movieData?.hall || halls[0]);
             setSelectedPredefinedMovie(currentTitle);
             setInternalMessage(message);
+            setFeatures(movieData?.features || { NL: false, OV: false, "2D": false, "3D": false });
         }
     }, [show, movieData, halls, message]);
 
@@ -81,6 +83,7 @@ function MovieModal({
             date,
             duration: parseInt(duration, 10),
             hall: selectedHall,
+            features,
         });
     };
 
@@ -143,6 +146,19 @@ function MovieModal({
                             <option key={hallName} value={hallName}>{hallName}</option>
                         ))}
                     </select>
+                    <div className="flex flex-wrap gap-2">
+                        {['NL', 'OV', '2D', '3D'].map((f) => (
+                            <label key={f} className="flex items-center gap-1 text-sm">
+                                <input
+                                    type="checkbox"
+                                    checked={features[f]}
+                                    onChange={(e) => setFeatures(prev => ({ ...prev, [f]: e.target.checked }))}
+                                    className="form-checkbox h-4 w-4 text-indigo-600"
+                                />
+                                <span>{f}</span>
+                            </label>
+                        ))}
+                    </div>
                     <button
                         onClick={handleSubmit}
                         className="w-full bg-indigo-500 hover:bg-indigo-600 active:bg-indigo-700 text-white font-bold py-3 px-6 rounded-lg transition-all duration-300 transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 mt-4"


### PR DESCRIPTION
## Summary
- allow marking features NL/OV/2D/3D when adding or editing a movie
- show selected features in movie cards and in film management overview
- keep track of feature selections in local storage and firestore
- place scheduler header navigation buttons on one line

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842fa07b8b48328ba1c4f7cf614f0de