### PR TITLE
Compact menus for more scheduler space

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -642,12 +642,12 @@ function App() {
 
                 /* Ensure the scheduler takes almost full width */
                 .scheduler-wrapper {
-                    background-color: rgba(139, 92, 246, 0.7); /* purple-700 with opacity */
-                    padding: 1.5rem; /* p-6 */
-                    border-radius: 0.75rem; /* rounded-xl */
-                    box-shadow: 0 20px 25px -5px rgba(0,0,0,0.2), 0 10px 10px -5px rgba(0,0,0,0.04); /* shadow-2xl */
-                    width: calc(100vw - 3rem); /* Almost full viewport width minus side padding */
-                    max-width: none; /* Override max-w from Tailwind */
+                    background-color: rgba(139, 92, 246, 0.7);
+                    padding: 1rem; /* compact padding */
+                    border-radius: 0.75rem;
+                    box-shadow: 0 20px 25px -5px rgba(0,0,0,0.2), 0 10px 10px -5px rgba(0,0,0,0.04);
+                    width: calc(100vw - 2rem);
+                    max-width: none;
                 }
 
                 /* Adjust margin top for main content if sticky header is used */
@@ -721,30 +721,30 @@ function App() {
                     {/* Conditional rendering based on currentPage */}
                     {currentPage === 'programming' && (
                         <div className="scheduler-wrapper">
-                            <h2 className="text-2xl font-semibold mb-5 text-center">Weekprogramma</h2>
+                            <h2 className="text-xl font-semibold mb-3 text-center">Weekprogramma</h2>
 
                             {/* Week Navigation */}
-                            <div className="flex flex-wrap justify-between items-center mb-4 px-2 gap-2">
+                            <div className="flex flex-wrap justify-between items-center mb-3 px-2 gap-2 text-sm">
                                 <button
                                     onClick={goToPreviousWeek}
-                                    className="bg-indigo-500 hover:bg-indigo-600 text-white py-2 px-4 rounded-lg transition-all duration-200 shadow-md"
+                                    className="bg-indigo-500 hover:bg-indigo-600 text-white py-1 px-2 rounded-md transition-all duration-200 shadow-md"
                                 >
                                     &larr; Vorige week
                                 </button>
-                                <span className="text-xl font-semibold text-center flex-grow">
+                                <span className="text-lg font-semibold text-center flex-grow">
                                     {new Intl.DateTimeFormat('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' }).format(currentWeekStart)}
                                     {' - '}
                                     {new Intl.DateTimeFormat('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' }).format(daysOfWeek[6].fullDate ? parseDate(daysOfWeek[6].fullDate) : new Date())}
                                 </span>
                                 <button
                                     onClick={goToNextWeek}
-                                    className="bg-indigo-500 hover:bg-indigo-600 text-white py-2 px-4 rounded-lg transition-all duration-200 shadow-md"
+                                    className="bg-indigo-500 hover:bg-indigo-600 text-white py-1 px-2 rounded-md transition-all duration-200 shadow-md"
                                 >
                                     Volgende week &rarr;
                                 </button>
                                 <button
                                     onClick={goToToday}
-                                    className="bg-purple-500 hover:bg-purple-600 text-white py-2 px-5 rounded-lg transition-all duration-200 shadow-md"
+                                    className="bg-purple-500 hover:bg-purple-600 text-white py-1 px-3 rounded-md transition-all duration-200 shadow-md"
                                 >
                                     Vandaag
                                 </button>

--- a/src/components/MenuBar.jsx
+++ b/src/components/MenuBar.jsx
@@ -12,35 +12,35 @@ function MenuBar({
     toggleViewMode
 }) {
     return (
-        <div className="bg-purple-800 text-white w-full py-3 px-6 shadow-xl flex flex-col sm:flex-row items-center justify-between sticky top-0 z-20">
-            <h1 className="text-xl font-bold mb-2 sm:mb-0 mr-4">Bioscoop Planner</h1>
-            <nav className="flex gap-4 mb-2 sm:mb-0">
+        <div className="bg-purple-800 text-white w-full py-2 px-4 shadow-xl flex flex-col sm:flex-row items-center justify-between sticky top-0 z-20 text-sm">
+            <h1 className="text-lg font-bold mb-1 sm:mb-0 mr-3">Bioscoop Planner</h1>
+            <nav className="flex gap-2 mb-1 sm:mb-0">
                 <button
                     onClick={() => setCurrentPage('programming')}
-                    className={`px-4 py-2 rounded-lg transition-colors duration-200 ${currentPage === 'programming' ? 'bg-indigo-600' : 'bg-purple-700 hover:bg-purple-600'}`}
+                    className={`px-3 py-1 rounded-md transition-colors duration-200 ${currentPage === 'programming' ? 'bg-indigo-600' : 'bg-purple-700 hover:bg-purple-600'}`}
                 >
                     Programmering
                 </button>
                 <button
                     onClick={() => setCurrentPage('movieManagement')}
-                    className={`px-4 py-2 rounded-lg transition-colors duration-200 ${currentPage === 'movieManagement' ? 'bg-indigo-600' : 'bg-purple-700 hover:bg-purple-600'}`}
+                    className={`px-3 py-1 rounded-md transition-colors duration-200 ${currentPage === 'movieManagement' ? 'bg-indigo-600' : 'bg-purple-700 hover:bg-purple-600'}`}
                 >
                     Filmbeheer
                 </button>
                 <button
                     onClick={() => setCurrentPage('settings')}
-                    className={`px-4 py-2 rounded-lg transition-colors duration-200 ${currentPage === 'settings' ? 'bg-indigo-600' : 'bg-purple-700 hover:bg-purple-600'}`}
+                    className={`px-3 py-1 rounded-md transition-colors duration-200 ${currentPage === 'settings' ? 'bg-indigo-600' : 'bg-purple-700 hover:bg-purple-600'}`}
                 >
                     Instellingen
                 </button>
             </nav>
-            <div className="flex flex-col sm:flex-row items-center gap-3 w-full sm:w-auto mt-2 sm:mt-0">
+            <div className="flex flex-col sm:flex-row items-center gap-2 w-full sm:w-auto mt-1 sm:mt-0">
                 {currentPage === 'programming' && (
                     <>
                         <select
                             value={selectedPredefinedMovieForQuickAdd}
                             onChange={handlePredefinedMovieForQuickAddChange}
-                            className="p-2 rounded-md bg-purple-700 border border-purple-500 text-white focus:outline-none focus:ring-2 focus:ring-purple-400 transition-all duration-200 appearance-none flex-grow"
+                            className="p-1 rounded-md bg-purple-700 border border-purple-500 text-white focus:outline-none focus:ring-2 focus:ring-purple-400 transition-all duration-200 appearance-none flex-grow text-sm"
                         >
                             {predefinedMovies.map((movie) => (
                                 <option key={movie.title} value={movie.title}>
@@ -51,7 +51,7 @@ function MenuBar({
 
                         {selectedPredefinedMovieForQuickAdd && selectedPredefinedMovieForQuickAdd !== 'Kies een film...' && (
                             <div
-                                className="draggable-movie-preview px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-md cursor-grab transition-colors duration-200 shadow-md"
+                                className="draggable-movie-preview px-3 py-1 bg-indigo-600 hover:bg-indigo-700 text-white rounded-md cursor-grab transition-colors duration-200 shadow-md text-sm"
                                 draggable="true"
                                 onDragStart={handleDragStart}
                             >
@@ -62,14 +62,14 @@ function MenuBar({
                 )}
                 <button
                     onClick={handleOpenMovieModal}
-                    className="px-4 py-2 bg-indigo-500 hover:bg-indigo-600 active:bg-indigo-700 text-white font-bold rounded-lg transition-all duration-300 transform hover:scale-105 shadow-md flex-shrink-0"
+                    className="px-3 py-1 bg-indigo-500 hover:bg-indigo-600 active:bg-indigo-700 text-white font-bold rounded-md transition-all duration-300 transform hover:scale-105 shadow-md flex-shrink-0 text-sm"
                 >
                     Film handmatig toevoegen
                 </button>
                 {currentPage === 'programming' && (
                     <button
                         onClick={toggleViewMode}
-                        className="px-4 py-2 bg-green-500 hover:bg-green-600 active:bg-green-700 text-white font-bold rounded-lg transition-all duration-300 transform hover:scale-105 shadow-md flex-shrink-0"
+                        className="px-3 py-1 bg-green-500 hover:bg-green-600 active:bg-green-700 text-white font-bold rounded-md transition-all duration-300 transform hover:scale-105 shadow-md flex-shrink-0 text-sm"
                     >
                         Schakel naar {viewMode === 'hall' ? 'Overzicht per dag' : 'Overzicht per zaal'}
                     </button>


### PR DESCRIPTION
## Summary
- compress menu bar layout and controls
- shrink week navigation buttons and header
- reduce scheduler wrapper padding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842fe4190408328857f97f61b141916