### PR TITLE
Improve drag-and-drop and compact menu bar

### DIFF
--- a/src/components/MenuBar.jsx
+++ b/src/components/MenuBar.jsx
@@ -12,8 +12,8 @@ function MenuBar({
     toggleViewMode
 }) {
     return (
-        <div className="bg-purple-800 text-white w-full py-2 px-4 shadow-xl flex flex-col sm:flex-row items-center justify-between sticky top-0 z-20 text-sm">
-            <h1 className="text-lg font-bold mb-1 sm:mb-0 mr-3">Bioscoop Planner</h1>
+        <div className="bg-purple-800 text-white w-full py-1 px-2 shadow-xl flex flex-col sm:flex-row items-center justify-between sticky top-0 z-20 text-sm">
+            <h1 className="text-base font-bold mb-1 sm:mb-0 mr-2">Bioscoop Planner</h1>
             <nav className="flex gap-2 mb-1 sm:mb-0">
                 <button
                     onClick={() => setCurrentPage('programming')}


### PR DESCRIPTION
## Summary
- store full drag data for better drag-and-drop
- fallback to stored data if dataTransfer is empty
- show a move cursor during drag
- make the menu bar more compact

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684314ff06788328b5e58a75512eea4a